### PR TITLE
Node backend and more

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -15,6 +15,9 @@
       </center>
     </div>
     <div id="shinglecontainer" data-width="100%" data-height="6in" data-graph-path="random-graph_500000/" data-node-field="nodenumber" ></div>
+    <!-- with use of the node mapServer.js
+    <div id="shinglecontainer" data-width="100%" data-height="6in" data-graph-path="data-graph-path="http://127.0.0.1:8088/shinglejs/random-graph_500000/"/" data-node-field="nodenumber" ></div>
+    -->
 
     <div class = "containerpadding" ></div>
 
@@ -176,6 +179,37 @@ More advanced parameters:
   <li><span class="shinglecode">fontFamily: "sans"</span> - font to use for text in the graph</li>
   <li><span class="shinglecode">fontColor: [r, g, b, a]</span> - color for text in the graph, specified as array of rgb or rgba values</li>  
   <li><span class="shinglecode">nodeColors: [[r, g, b, a], .. ]</span> - color scheme, array of colors to use in the graph for the communities, the colors are specified as arrays of rgb or rgba values, and cycles if the number of communities exceeds the number of colors</li>
+  <li><span class="shinglecode">renderWhenNodeNotFound</span> - when false no map is displayed, default true</li>
+  <li><span class="shinglecode">selectNodes</span> - can the user select nodes by clicking or touching them? default true</li>
+  <li><span class="shinglecode">panning</span> - dragging the map is allowed? default true</li>
+  <li><span class="shinglecode">zoomSlider</span> - can the user zoom in / out using a zoomslider? default false</li>
+  <li><span class="shinglecode">staticMap</span> - disable zooming, panning and selecting nodes, default false</li>
+  <li><span class="shinglecode">showRelatedNodeNames</span> - false, true (display related node names), 'hover' (display on hover of related node)</li>
+  <li><span class="shinglecode">fontSize</span> - option to set a fixed fontsize in px for display, default 18</li>
+  <li><span class="shinglecode">textGrow</span> - will the text grow when the zoomlevel increases above initialzoom?</li>default true</li>
+  <li><span class="shinglecode">textShrink</span> - will the text shrink when the zoomlevel increases above initialzoom? default false</li>
+  <li>textGrow and textShrink increase or decrease the font size displayed linear to the zoomlevel</li>
+  <li><span class="shinglecode">relatedFontSize</span> - font size for related nodes names when displayed</li>
+  <li><span class="shinglecode">translateOffsetX</span> - added SVG CSS X translate offset</li>
+  <li><span class="shinglecode">translateOffsetY</span> - added SVG CSS Y translate offset</li>
+</ul>
+</p>
+
+<p>
+More advanced callback function parameters:
+<ul>
+  <li><span class="shinglecode">onNodeNotFound</span> - callback function called when node specified by nodeid parameter was not found</li>
+  <li><span class="shinglecode">onQuadsDrawn</span> - called each time quads are drawn</li>
+  <li><span class="shinglecode">onFirstQuadDrawn</span> - called the first time a quad is drawn</li>
+</ul>
+</p>
+
+<p>
+Functions to use with the shingle object (returned by shingle.new):
+<ul>
+  <li><span class="shinglecode">zoomIn</span> - zoom in using step supplied in option zoomStep, default 5%</li>
+  <li><span class="shinglecode">zoomOut</span> - zoom out using step supplied in option zoomStep, default 5%</li>
+  <li><span class="shinglecode">zoomReset</span> - reset zoom level to option intitialZoom</li>
 </ul>
 </p>
 

--- a/html/shingleInfoPanel.js
+++ b/html/shingleInfoPanel.js
@@ -65,7 +65,12 @@ function shingleInfoPanel(settings) {
 
 			var moreOnNode = ''; //GetMoreOnNode(nodeid);
 
-			mainNode.innerHTML = "<span class=\"shingle-info-node\" id=\"node-" + nodeid + "\" data-nodeid=\"" + nodeid + "\" data-quadid-=\"" + quadid + "\" >" + name + "</span> " + nodeid + "<br>" + moreOnNode + "<hr>";
+			if(data.href) {
+				mainNode.innerHTML = "<a href=\"" + data.href + "\" target=\"tabNode" + nodeid + "\" class=\"shingle-info-node\" id=\"node-" + nodeid + "\" data-nodeid=\"" + nodeid + "\" data-quadid-=\"" + quadid + "\" >" + name + "</a> " + nodeid + "<br>" + moreOnNode + "<hr>";
+			} else {
+				mainNode.innerHTML = "<span class=\"shingle-info-node\" id=\"node-" + nodeid + "\" data-nodeid=\"" + nodeid + "\" data-quadid-=\"" + quadid + "\" >" + name + "</span> " + nodeid + "<br>" + moreOnNode + "<hr>";
+			}
+
 			var mainNodeEl = mainNode.getElementsByClassName('shingle-info-node');
 			self.nodeInfoEls[nodeid] = mainNodeEl[0];
 

--- a/node/README.txt
+++ b/node/README.txt
@@ -1,0 +1,17 @@
+The nodejs mapServer.js can be used to increase performance when using very large graphs.
+
+You can run mapServer.js in a directory of choice (or the preinstalled dir), but preferably outside the public www directory.
+
+Use of this requires the expressjs module, see http://expressjs.com
+to install use npm install express
+
+To run mapServer.js for a graph:
+- create a config file for the graph (see the example mapConfigRandomGraph500000.js config file)
+- start using node mapServer <mapConfigFile> (no need to supply .js extensions)
+
+To run in the background you can use the & and optionally the nohup to keep it running
+- nohup node mapServer <mapConfigFile> &
+
+Or install like you would install any other deamon process.
+
+Don't forget: in your frontend, use the host:port/uri sepcified in the config file.

--- a/node/README.txt
+++ b/node/README.txt
@@ -14,4 +14,8 @@ To run in the background you can use the & and optionally the nohup to keep it r
 
 Or install like you would install any other deamon process.
 
-Don't forget: in your frontend, use the host:port/uri sepcified in the config file.
+Don't forget: in your frontend, use the host:port/uri specified in the config file.
+
+NOTE
+- you can run multiple instances for different graphs (different config files)
+- make sure each mapServer instance runs on a different port, a port which is not yet in use on your server

--- a/node/mapConfigRandomGraph500000.js
+++ b/node/mapConfigRandomGraph500000.js
@@ -1,0 +1,21 @@
+/*
+ *	map config for use with mapServer.js
+ *
+ *	NOTE: use one config file for each map you want to use the mapServer for
+ *
+ *	Start mapserver using: node mapServer <mapConfigFile> (no need to supply .js extensions)
+ */
+
+var config = {
+	// host and port to listen on, required
+	host: 'localhost',
+	port: '8088',
+	// the base url to listen on, required
+	baseUri: '/shinglejs/random-graph_500000/',
+	// the base directory in which the map file reside (mapinfo, table*.json, quad*.json, ..), required
+	baseDir: '/<path>/<to>/random-graph_500000',
+	// setting this to false might be useful with small quad files
+	mapsNodeRelations: false
+};
+
+module.exports = config;

--- a/node/mapServer.js
+++ b/node/mapServer.js
@@ -1,0 +1,376 @@
+/*
+ *	SERVE map info and quads for use with Shingle.js
+ *
+ *	NOTE this requires the expressjs module, see http://expressjs.com
+ *
+ *	A config file is needed for each map you want to use mapServer for
+ *
+ *	Start mapserver using: node mapServer <mapConfigFile> (no need to supply .js extensions)
+ */
+
+// check startup parameters first
+var arguments = process.argv.slice(2);
+
+if(arguments.length < 1) {
+	console.log('No map config file supplied');
+	console.log('Usage: node mapServer <mapConfigFile>');
+	process.exit(1);
+}
+
+// load supplied map config file
+var configFile = arguments[0], config;
+try {
+	config = require("./" + configFile);
+} catch(e) {
+	console.log('Invalid map config file supplied');
+	console.log(e);
+	process.exit(1);
+}
+
+// check config file
+if(!config.host || !config.port || !config.baseUri || !config.baseDir) {
+	console.log('Map config file is missing required settings, see example config file for details');
+	process.exit(1);
+}
+
+// set base
+if(config.baseUri.substr(-1) != '/') config.baseUri += '/';
+if(config.baseDir.substr(-1) != '/') config.baseDir += '/';
+
+// load required modules
+var fs = require("fs"),
+	extend = require('util')._extend,
+	express = require('express');
+
+// load global mapinfo file
+var data = loadFileSync('mapinfo.json');
+if(!data) {
+	console.log('Map config file does not use a valid baseDir, the directory does not exists, is not accessible or does not contain mapinfo.json');
+	process.exit(1);
+}
+
+// mapinfo OK
+var mapInfoStr = data.toString(),
+	mapInfo = JSON.parse(mapInfoStr);
+
+// prepare data objects
+var root = extend({}, mapInfo.quadtree);
+mapInfo.quadtree = {
+	xmin: root.xmin,
+	xmax: root.xmax,
+	ymin: root.ymin,
+	ymax: root.ymax
+};
+
+// locally cached objects
+var quadNodeRelations = {};
+
+// set a flag for the frontend
+mapInfo.loadFromBackend = true;
+mapInfo.backendMapsNodeRelations = config.mapsNodeRelations;
+
+// global functions
+function getPathLast(path) {
+	var pathArr = path.split('/'),
+		pathLast = pathArr.length ? pathArr[pathArr.length - 1] : false;
+
+	// note it can contain a query string, strip this
+	return pathLast.split('?')[0];
+};
+function loadFileSync(fileName) {
+	try {
+		var stats = fs.statSync(config.baseDir + fileName);
+		return fs.readFileSync(config.baseDir + fileName);
+	} catch(e) {
+		return false;
+	}
+};
+function loadFile(fileName, success, error) {
+	fs.stat(config.baseDir + fileName, function(err, stat) {
+		if(err == null) {
+			fs.readFile(config.baseDir + fileName, function (err, data) {
+				if (!err) {
+					success(data.toString());
+				} else {
+					error(err);
+				}
+			});
+		} else {
+		    error(err.code);
+		}
+	});
+};
+function quadIntersects(screenrect, root) {
+	if (root.xmin < screenrect.xmax && root.xmax > screenrect.xmin &&
+		root.ymin < screenrect.ymax && root.ymax > screenrect.ymin) {
+		return true;
+	}
+	return false;
+};
+function findQuadsToDraw(screenrect) {
+	var quadid = "quad_",
+		quads = [];
+
+	findQuadsToDrawRecursive(screenrect, root, quadid, quads);
+	return quads;
+};
+function findQuadsToDrawRecursive(screenrect, root, quadid, quads) {
+
+	if (quadIntersects(screenrect, root)) {
+		if (root["type"] == "Leaf") {
+			quads.push(quadid);
+		} else {
+			findQuadsToDrawRecursive(screenrect, root.left, (quadid + "l"), quads);
+			findQuadsToDrawRecursive(screenrect, root.right, (quadid + "r"), quads);
+		}
+	}
+};
+
+// process quads
+// - relations
+// - max #relations to return
+function processQuad(quadid, data, callback) {
+
+	quadNodeRelations[quadid] = {
+		processing: true,
+		nodeRelations: {}
+	};
+
+	try {
+		var quad = JSON.parse(data),
+			relations = [],
+			nodeRelations = {},
+			nodeMap = {};
+
+		if(quad.relations && quad.relations.length) {
+
+			var relationsToProcess = quad.relations;
+			delete quad.relations;
+
+			// first assemble the relations to return (to draw always)
+			// max # relations to return, this should be a parameter / setting in shingle
+			for (var i = 0; i < Math.min(relationsToProcess.length, 100); i++) {
+				relations.push(relationsToProcess[i]);
+			};
+			quad.relations = relations;
+
+			// callback can be done now, findRelation waits for below to finish async
+			callback(quad);
+
+			// create the node relations mapping
+			for (var i = 0; i < relationsToProcess.length; i++) {
+
+				var entry = relationsToProcess[i];
+
+				if(entry.nodeidA && entry.nodeidB) {
+					if(!nodeRelations[entry.nodeidA]) nodeRelations[entry.nodeidA] = {
+						quad: entry.quadA,
+						toNodes: []
+					};
+					if(!nodeRelations[entry.nodeidB]) nodeRelations[entry.nodeidB] = {
+						quad: entry.quadB,
+						toNodes: []
+					};
+					nodeRelations[entry.nodeidA].toNodes.push({
+						node: entry.nodeidB,
+						quad: entry.quadB,
+					});
+					nodeRelations[entry.nodeidB].toNodes.push({
+						node: entry.nodeidA,
+						quad: entry.quadA,
+					});
+				}
+			};
+			quadNodeRelations[quadid].nodeRelations = nodeRelations;
+
+		} else {
+			callback(quad);
+		}
+	} catch(e) {
+		console.log(e);
+		callback(false);
+	}
+
+	quadNodeRelations[quadid].processing = false;
+};
+
+// create / start the mapinfo server
+var app = express();
+
+// cors, allow from all for now ..
+app.use(function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
+
+// when no php proxy: app.use(express.compress());
+// cors, allow from all for now ..
+/*
+app.use(function(req, res, next) {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+}, express.compress());
+*/
+
+// main mapinfo
+app.get(config.baseUri + 'mapinfo.json', function (req, res, next) {
+	res.setHeader('Content-Type', 'application/json');
+	res.end( JSON.stringify(mapInfo) );
+});
+
+
+/*
+ * findRelations
+ * url parameters:
+ * - nodeid
+ */
+app.get(config.baseUri + 'findRelations', function (req, res, next) {
+
+	// get and return the relations
+	function returnRelations() {
+	 	if(quadNodeRelations[req.query.quadid].nodeRelations[req.query.nodeid]) {
+			res.setHeader('Content-Type', 'application/json');
+			res.end( JSON.stringify(quadNodeRelations[req.query.quadid].nodeRelations[req.query.nodeid]) );
+		} else {
+			res.sendStatus(404);
+		}
+	};
+
+	// the quad in which relations are has been fetched but it may be still processing
+	if(req.query.quadid && req.query.nodeid && quadNodeRelations[req.query.quadid]) {
+		if(quadNodeRelations[req.query.quadid].processing) {
+
+			// wait quad being processed
+			var tries = 0,
+				watcher = setInterval(function() {
+
+					tries++;
+					if(!quadNodeRelations[req.query.quadid].processing) {
+						clearInterval(watcher);
+						returnRelations();
+					} else {
+						if(tries > 99) {
+							clearInterval(watcher);
+							returnRelations();
+						}
+					}
+
+				}, 50);
+	
+		} else {
+			returnRelations();	
+		}
+	}
+});
+
+// debug backend page
+app.get(config.baseUri + 'showNodeRelations', function (req, res, next) {
+	var result;
+
+	if(req.query.quadid && req.query.nodeid) {
+		result = quadNodeRelations[req.query.quadid].nodeRelations[req.query.nodeid];
+	} else if(req.query.quadid) {
+		result = quadNodeRelations[req.query.quadid];
+	} else {
+		result = quadNodeRelations;
+	}
+
+	res.setHeader('Content-Type', 'application/json');
+	res.end( JSON.stringify(result) );
+});
+
+/*
+ * findQuads
+ * url parameters (screenrect):
+ * - xmin
+ * - ymin
+ * - xmax
+ * - ymax
+ */
+app.get(config.baseUri + 'findQuads', function (req, res, next) {
+
+	//find in root based on screenrect and quad coordinated
+	if(req.query.xmin && req.query.ymin && req.query.xmax && req.query.ymax) {
+		var quads = findQuadsToDraw({
+			xmin: req.query.xmin,
+			ymin: req.query.ymin,
+			xmax: req.query.xmax,
+			ymax: req.query.ymax
+		});
+		res.setHeader('Content-Type', 'application/json');
+		res.end( JSON.stringify(quads) );
+	}
+});
+
+// tables
+app.get(config.baseUri + 'table*.json', function (req, res, next) {
+
+	var tableName = getPathLast(req.originalUrl);
+
+	if(tableName) {
+		loadFile(tableName, function(data) {
+			res.setHeader('Content-Type', 'application/json');
+			if(req.query.nodeid) {
+				var tabObj = JSON.parse(data),
+					resObj = {};
+
+				if(tabObj[req.query.nodeid]) {
+					resObj[req.query.nodeid] = tabObj[req.query.nodeid];
+				}
+				res.send( JSON.stringify(resObj) );
+			} else {
+				res.send( data );
+			}
+		}, function(err) {
+			res.sendStatus(404);
+		});
+	} else {
+		res.sendStatus(404);
+	}
+});
+
+// quads
+app.get(config.baseUri + 'quad*.json', function (req, res, next) {
+
+	var quadName = getPathLast(req.originalUrl);
+
+	if(quadName) {
+
+		var quadid = quadName.split('.json')[0];
+
+		loadFile(quadName, function(data) {
+
+			if(mapInfo.backendMapsNodeRelations) {
+				processQuad(quadid, data, function(quad) {
+					if(quad && quad.relations) {
+						res.setHeader('Content-Type', 'application/json');
+						res.send( JSON.stringify(quad) );
+					} else {
+						res.sendStatus(500);
+					}
+				});
+			} else {
+				res.setHeader('Content-Type', 'application/json');
+				res.send( data );
+			}
+
+		}, function(err) {
+			res.sendStatus(404);
+		});
+	} else {
+		res.sendStatus(404);
+	}
+});
+
+//
+// start the server
+var server = app.listen(config.port, config.host, function () {
+	var host = server.address().address
+	var port = server.address().port
+
+	console.log('Running SingleJS map server at http://%s:%s%s', host, port, config.baseUri);
+	console.log('Using baseDir: ', config.baseDir);
+	console.log('Using mapinfo: ', mapInfo);
+});


### PR DESCRIPTION
CHANGES in this feature branch:

Changed default width to 100%

Capability to specify nodeId also as an option

Options when the node supplied in parameter nodeField (default nodeid) was not found
* renderWhenNodeNotFound: when false no map is displayed, default true
* onNodeNotFound: callback function called when node not found

Functions for triggering zoom programmatically
* zoomIn: zoom in using step supplied in option zoomStep, default 5%
* zoomOut: zoom out using step supplied in option zoomStep, default 5%
* zoomReset: reset zoom level to option intitialZoom

Options for interacting with the map
* selectNodes: can the user select nodes by clicking or touching them? default true
* panning: dragging the map is allowed? default true
* zoomSlider: can the user zoom in / out using a zoomslider? default false
* staticMap: disable zooming, panning and selecting nodes, default false

Behaviour for displaying names of related nodes of a selected node using a new option
* showRelatedNodeNames: false, true (display related node names), 'hover' (display on hover of related node)

Options for controlling font size of the node names, rendered as a fixed size in screen px indepenent of scaling
new options:
* fontSize: option to set a fixed fontsize in px for display, default 18
* textGrow: will the text grow when the zoomlevel increases above initialzoom? default true
* textShrink: will the text shrink when the zoomlevel increases above initialzoom? default false
textGrow and textShrink increase or decrease the font size displayed linear to the zoomlevel
* relatedFontSize: font size for related nodes names when displayed

Fixed too large stroke-width of nodes in maps with wider lines, calculate from average quad width instead of average line length

Options to use offset factors for CSS translate of the SVG element:
* translateOffsetX
* translateOffsetY

Fix bug non-unique classNames when using multiple graphs in a page

Bugfix for highlighted node being redrawn are each cycle of drawing the related nodes, which is done in async cycles of 100 nodes at a time

Render callbacks when graph actually displayed:
* onQuadsDrawn: called each time quads are drawn
* onFirstQuadDrawn: called the first time a quad is drawn

Ability to use a nodejs based backend (mapServer) for faster rendering of large graphs. 

Changes to the documentation, the shingle website.

Nodejs backend mapServer.js for use with large graph, in the node directory.