### PR TITLE
The mapServer now caches the mapped quad relations both in memory and…

### DIFF
--- a/node/mapConfigRandomGraph500000.js
+++ b/node/mapConfigRandomGraph500000.js
@@ -15,7 +15,22 @@ var config = {
 	// the base directory in which the map file reside (mapinfo, table*.json, quad*.json, ..), required
 	baseDir: '/<path>/<to>/random-graph_500000',
 	// setting this to false might be useful with small quad files
-	mapsNodeRelations: false
+	mapsNodeRelations: true,
+	//
+	// memory settings
+	// memory usage stats can be queried at http://host:port/baseUri/stats
+	// with quads details: http://host:port/baseUri/stats?view=complete
+	//
+	// cache no more quads (relation mappings) than this value, only has impact when mapsNodeRelations = true
+	memoryMaxQuadsToCache: 25,
+	// the memory cleanup (discarding the excess quads above memoryMaxQuadsToCache) cycle time
+	memoryCleanupCycleTime: 30,
+	// warning when memory usage (resident set) exceeds this size in Mbytes
+	// default is 256M, which in most cases is safe with a memoryMaxQuadsToCache value of 25
+	// this can be used for (automated) monitoring, using host:port/baseUri/memoryMonitor
+	// request to this page will only respond with a 200 response containting the text WARNING when the warning
+	// level is exceeded, otherwise it will respond with a 404
+	memoryUsageWarningThreshold: 256
 };
 
 module.exports = config;


### PR DESCRIPTION
The mapServer now caches the mapped quad relations both in memory and in files, for which it creates a cache directory (per graph / config file).

It only keeps relations in memory for a limited number of quads, as specified in the config file in the memoryMaxQuadsToCache parameter.

In addition it offers monitoring and warnings for memory usage.

The memory stats can be retrieved with an API:
http://host:port/baseUri/stats
http://host:port/baseUri/stats?view=complete (with quad details)

Also an alert monitor page can be used for use in service watchers like uptime robot or pingdom, this page is available at:
http://host:port/baseUri/memoryMonitor

For use with watchers this page only returns a 200 response with the text WARNING when the mapServer node process exceeds the memory usage specified in the config file in parameter memoryUsageWarningThreshold.